### PR TITLE
Resolves #2

### DIFF
--- a/lib/middlegem/array_definition.rb
+++ b/lib/middlegem/array_definition.rb
@@ -108,7 +108,7 @@ module Middlegem
     # @param middleware [Object] the middleware to check.
     # @return [bool] whether the middleware is defined.
     def defined?(middleware)
-      defined_classes.include?(middleware.class)
+      defined_classes.any? { |c| matches_class?(middleware, c) }
     end
 
     # Sorts the given array of middlewares according to this {ArrayDefinition}. Middlewares are
@@ -121,6 +121,19 @@ module Middlegem
       defined_classes.map { |c| resolver.call(matches(middlewares, c)) }.flatten
     end
 
+    protected
+
+    # Should determine whether the given middleware's evaluated class is equal to the given one.
+    # The default implementation naturally just uses +instance_of?+, but you are free to
+    # override this method for other situations. You may want is use +is_a?+ instead, for
+    # example, or perhaps a middleware's "class" is based on some other criterion.
+    # @param middleware [Object] the middleware to check.
+    # @param klass [Class] the class against which to check the middleware.
+    # @return [Boolean] whether the given middleware has the given class.
+    def matches_class?(middleware, klass)
+      middleware.instance_of? klass
+    end
+
     private
 
     # Gets all the middlewares in the given array whose class is the given class.
@@ -128,7 +141,7 @@ module Middlegem
     # @param klass [Class] the class to search for.
     # @return [Array<Object>] the matched middlewares.
     def matches(middlewares, klass)
-      middlewares.select { |m| m.instance_of?(klass) }
+      middlewares.select { |m| matches_class?(m, klass) }
     end
   end
 end

--- a/spec/middlegem/array_definition_spec.rb
+++ b/spec/middlegem/array_definition_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'support/test_middleware'
 require 'support/another_middleware'
 require 'support/blocked_middleware'
+require 'support/official_middleware'
+require 'support/overriden_array_definition'
 
 RSpec.describe Middlegem::ArrayDefinition do
   let(:definition_list) do
@@ -25,6 +27,21 @@ RSpec.describe Middlegem::ArrayDefinition do
     context 'when given an object whose class is not in the definition list' do
       it 'returns false' do
         expect(definition.defined?(BlockedMiddleware.new)).to eq false
+      end
+    end
+
+    context 'when matches_class? is overriden' do
+      let(:definition_list) do
+        [
+          Middlegem::Middleware,
+          TestMiddleware,
+          AnotherMiddleware
+        ]
+      end
+      let(:definition) { OverridenArrayDefinition.new(definition_list) }
+
+      it 'respects it' do
+        expect(definition.defined?(OfficialMiddleware.new(5))).to eq true
       end
     end
   end
@@ -75,6 +92,28 @@ RSpec.describe Middlegem::ArrayDefinition do
 
       it 'correctly utilizes it' do
         expect(sorted.map(&:num)).to eq [1, 4, 2, 5, 3]
+      end
+    end
+
+    context 'when matches_class? is overriden' do
+      let(:definition_list) do
+        [
+          Middlegem::Middleware,
+          TestMiddleware,
+          AnotherMiddleware
+        ]
+      end
+      let(:middlewares) do
+        [
+          AnotherMiddleware.new(1, [], priority: 2),
+          OfficialMiddleware.new(2),
+          TestMiddleware.new(3, [], priority: 1)
+        ]
+      end
+      let(:definition) { OverridenArrayDefinition.new(definition_list) }
+
+      it 'respects it' do
+        expect(sorted.map(&:num)).to eq [2, 3, 1]
       end
     end
   end

--- a/spec/support/official_middleware.rb
+++ b/spec/support/official_middleware.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class OfficialMiddleware < Middlegem::Middleware
+  attr_reader :num
+
+  def initialize(num)
+    @num = num
+
+    super()
+  end
+
+  def call(input)
+    "Official: #{input}!"
+  end
+end

--- a/spec/support/overriden_array_definition.rb
+++ b/spec/support/overriden_array_definition.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class OverridenArrayDefinition < Middlegem::ArrayDefinition
+  protected
+
+  def matches_class?(middleware, klass)
+    middleware.is_a? klass
+  end
+end


### PR DESCRIPTION
Resolves Issue #2 by adding a new `#matches_class?` method to ArrayDefinition that allows customization over how exactly classes are matched.
